### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
         depends_on:
             - Portainer
             - Webserver
-        image: iproyalpawns/pawns-cli:latest
+        image: iproyal/pawns-cli:latest
         command: -email=$IPROYALPAWNS_EMAIL -password='$IPROYALPAWNS_PASSWD' -device-name=$DEVICE_NAME -accept-tos
         restart: always
         networks:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/87787929/193438668-9028e261-0889-4af9-8363-011e1802f67e.png)
`iproyalpawns/pawns-cli:latest` is old docker image, that can't be use