### PR TITLE
Replace EarnApp Image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
         depends_on:
             - Portainer
             - Webserver
-        image: fazalfarhan01/earnapp:lite
+        image: madereddy/earnapp:latest
         volumes:
             - earnapp-data:/etc/earnapp
         restart: always


### PR DESCRIPTION
fazalfarhan01/earnapp:lite hasnt been updated in over a year.

Forked a repo and automated updates for the lite container to make sure the latest earn app version is always present.